### PR TITLE
fix: import path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,12 +1,12 @@
-from custom_nodes.Comfy_KepListStuff.nodes.deprecated import StackImages
-from custom_nodes.Comfy_KepListStuff.nodes.images import (
+from .nodes.deprecated import StackImages
+from .nodes.images import (
     ImageLabelOverlay,
     EmptyImages,
     XYImage,
     ImageListLoader,
     VariableImageBuilder,
 )
-from custom_nodes.Comfy_KepListStuff.nodes.list_utils import (
+from .nodes.list_utils import (
     ListLengthNode,
     JoinFloatLists,
     JoinImageLists,
@@ -16,13 +16,13 @@ from custom_nodes.Comfy_KepListStuff.nodes.list_utils import (
     JoinListAny,
     StringListFromNewline,
 )
-from custom_nodes.Comfy_KepListStuff.nodes.range_nodes import (
+from .nodes.range_nodes import (
     IntRangeNode,
     FloatRangeNode,
     IntNumStepsRangeNode,
     FloatNumStepsRangeNode,
 )
-from custom_nodes.Comfy_KepListStuff.nodes.xy import UnzippedProductAny
+from .nodes.xy import UnzippedProductAny
 
 NODE_CLASS_MAPPINGS = {
     "Range(Step) - Int": IntRangeNode,

--- a/nodes/deprecated.py
+++ b/nodes/deprecated.py
@@ -4,7 +4,7 @@ from PIL import ImageFont, Image, ImageDraw
 from torch import Tensor
 import matplotlib.font_manager as fm
 
-from custom_nodes.Comfy_KepListStuff.utils import tensor2pil, pil2tensor
+from ..utils import tensor2pil, pil2tensor
 
 # Hack: string type that is always equal in not equal comparisons
 class AnyType(str):

--- a/nodes/images.py
+++ b/nodes/images.py
@@ -7,7 +7,7 @@ from PIL import ImageFont, ImageDraw, Image
 import matplotlib.font_manager as fm
 from torch import Tensor
 
-from custom_nodes.Comfy_KepListStuff.utils import (
+from ..utils import (
     zip_with_fill,
     tensor2pil,
     pil2tensor,

--- a/nodes/list_utils.py
+++ b/nodes/list_utils.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Tuple
 
 from torch import Tensor
 
-from custom_nodes.Comfy_KepListStuff.utils import AnyType
+from ..utils import AnyType
 
 any_type = AnyType("*")
 

--- a/nodes/range_nodes.py
+++ b/nodes/range_nodes.py
@@ -4,7 +4,7 @@ from typing import Iterator, List, Tuple, Dict, Any, Union, Optional
 
 import numpy as np
 
-from custom_nodes.Comfy_KepListStuff.utils import (
+from ..utils import (
     error_if_mismatched_list_args,
     zip_with_fill,
 )


### PR DESCRIPTION
Remove the assumption that the path name of the custom node is always the same.

Going forward, the node name will not be used as is in ComfyUI-Manager. 
Importing it like `custom_nodes.ComfyUI_KepListStuff` will cause issues.