### PR TITLE
Minor fixes on ImageLabelOverlay and  JoinListAny

### DIFF
--- a/nodes/images.py
+++ b/nodes/images.py
@@ -29,7 +29,7 @@ class ImageLabelOverlay:
             "optional": {
                 "float_labels": ("FLOAT", {"forceInput": True}),
                 "int_labels": ("INT", {"forceInput": True}),
-                "str_labels": ("STR", {"forceInput": True}),
+                "str_labels": ("STRING", {"forceInput": True}),
             },
         }
 

--- a/nodes/list_utils.py
+++ b/nodes/list_utils.py
@@ -72,10 +72,10 @@ class JoinListAny:
             },
         }
 
-    RETURN_TYPES = (any_type,)
+    RETURN_TYPES = (any_type, "INT")
     RETURN_NAMES = ("Joined", "Sizes")
     INPUT_IS_LIST = True
-    OUTPUT_IS_LIST = (True,)
+    OUTPUT_IS_LIST = (True, True)
     FUNCTION = "join_lists"
 
     CATEGORY = "List Stuff"


### PR DESCRIPTION
Node ImageLabelOverlay : The type of the "str_labels" input was "STR" instead of "STRING".
Node  JoinListAny : Output type was missing for "Sizes", it did not show up in the UI